### PR TITLE
Add access logging configuration

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -66,6 +66,15 @@ resource "aws_s3_bucket" "bucket" {
   }
 
   tags = merge(var.tags)
+
+  dynamic "logging" {
+    for_each = length(keys(var.bucket_logging)) == 0 ? [] : [var.bucket_logging]
+
+    content {
+      target_bucket = logging.value.target_bucket
+      target_prefix = lookup(logging.value, "target_prefix", null)
+    }
+  }
 }
 
 resource "aws_s3_bucket_object" "bucket_public_keys_readme" {

--- a/variables.tf
+++ b/variables.tf
@@ -12,6 +12,12 @@ variable "bucket_force_destroy" {
   description = "The bucket and all objects should be destroyed when using true"
 }
 
+variable "bucket_logging" {
+  description = "Map containing access logging configuration for the log bucket"
+  type        = map(string)
+  default     = {}
+}
+
 variable "tags" {
   description = "A mapping of tags to assign"
   default     = {}


### PR DESCRIPTION
## Description of this change
This PR allows the callers to configure access logging for the bastion log bucket

## Why is this change being made?
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested? How can the reviewer verify your testing?
```
$ terraform init && terraform validate
```

## Related issues
KD-1151

## Checklist
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have evaluated the security impact of this change, and [OWASP Secure Coding Practices](https://owasp.org/www-project-secure-coding-practices-quick-reference-guide/migrated_content#) have been observed.
- [x] I have informed stakeholders of my changes.

![](https://media.giphy.com/media/xUNd9AWdxcVN2aOWas/giphy.gif)